### PR TITLE
Fix CPU usage display on macOS

### DIFF
--- a/scripts/cpu_collect.sh
+++ b/scripts/cpu_collect.sh
@@ -16,11 +16,11 @@ get_cpu_usage() {
   if is_osx; then
     if command_exists "iostat"; then
       iostat -w "$refresh_interval" -c "$samples_count" \
-        | stdbuf -o0 awk 'NR > 2 { print 100-$(NF-3); }'
+        | gstdbuf -o0 awk 'NR > 2 { print 100-$(NF-3); }'
     else
       top -l "$samples_count" -s "$refresh_interval" -n 0 \
         | sed -u -nr '/CPU usage/s/.*,[[:space:]]*([0-9]+[.,][0-9]*)%[[:space:]]*idle.*/\1/p' \
-        | stdbuf -o0 awk '{ print 100-$0 }'
+        | gstdbuf -o0 awk '{ print 100-$0 }'
     fi
   elif ! command_exists "vmstat"; then
     if is_freebsd; then


### PR DESCRIPTION
Use `gstdbuf` instead of `stdbuf` on macOS to correctly display the CPU usage.